### PR TITLE
Add bDestroyResponseOnSubmit as a global setting

### DIFF
--- a/ZestHook.php
+++ b/ZestHook.php
@@ -57,6 +57,16 @@
           	'label' => 'Zest server id token',
             'help'=>'To get a token logon to your account, go to your servers and copy the server id',
         	  ),
+            'bDestroyResponseOnSubmit' => array(
+                'type' => 'select',
+                'label' => 'Destroy response on submission',
+                'options'=>array(
+                  0=> 'No',
+                  1=> 'Yes'
+                ),
+                'default'=>0,
+                'help'=>'Set to Yes if you want to remove survey response from server after submission',
+            ),
             'bDebugMode' => array(
             'type' => 'select',
             'options'=>array(
@@ -217,6 +227,11 @@
           $hookSent = $this->httpPost($url,$parameters);
 
           $this->debug($parameters, $hookSent, $time_start);
+          if ($response != null && $this->get('bDestroyResponseOnSubmit',null,null,$this->settings['bDestroyResponseOnSubmit']) == 1)
+          {
+            $responseObject = $this->api->getResponse($sSurveyId, $responseId, false);
+            $responseObject->delete();
+          }
 
           return;
         }


### PR DESCRIPTION
Webhooks allow us to send survey responses to destinations where we have
better control over access and privacy of data, from LimeSurvey hosts that we may have less
control. 

As such, allow LimeSurvey admins to destroy survey responses once the webhook has been successfully submitted, so that we may ensure that no data is retained on such LimeSurvey hosts, thereby avoiding a potential leak resulting from the compromise of such servers